### PR TITLE
feat:Migração - Atualização do Schema raw_mv

### DIFF
--- a/migrations/versions/03f4a8600026_inclusao_dos_campos_reg_amb_e_reg_fat.py
+++ b/migrations/versions/03f4a8600026_inclusao_dos_campos_reg_amb_e_reg_fat.py
@@ -1,0 +1,33 @@
+"""Inclusao dos campos reg_amb e reg_fat
+
+Revision ID: 03f4a8600026
+Revises: a46b6f2040af
+Create Date: 2025-04-17 14:35:35.172392
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '03f4a8600026'
+down_revision: Union[str, None] = 'a46b6f2040af'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+
+
+    op.add_column('reg_amb', sa.Column('DT_REG_AMB', sa.DateTime(), nullable=True))
+    op.add_column('reg_fat', sa.Column('DT_REG_FAT', sa.DateTime(), nullable=True))
+
+
+
+def downgrade() -> None:
+
+    op.drop_column('reg_fat', 'DT_REG_FAT')
+    op.drop_column('reg_amb', 'DT_REG_AMB')
+

--- a/migrations/versions/2a9fd0e7d055_inclusao_campo_cd_prestador_na_tabela_.py
+++ b/migrations/versions/2a9fd0e7d055_inclusao_campo_cd_prestador_na_tabela_.py
@@ -1,0 +1,30 @@
+"""Inclusao campo CD_PRESTADOR na tabela ATENDIME
+
+Revision ID: 2a9fd0e7d055
+Revises: 03f4a8600026
+Create Date: 2025-04-19 18:33:38.772617
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '2a9fd0e7d055'
+down_revision: Union[str, None] = '03f4a8600026'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+
+    op.add_column('atendime', sa.Column('CD_PRESTADOR', sa.String(), nullable=True))
+
+
+
+def downgrade() -> None:
+
+    op.drop_column('atendime', 'CD_PRESTADOR')
+

--- a/models.py
+++ b/models.py
@@ -326,8 +326,9 @@ class Atendime(Base):
 
     id_atendime_seq = Sequence('id_atendime_seq', schema='public')
     id_atendime = Column(BigInteger, primary_key=True, server_default=text("nextval('public.id_atendime_seq'::regclass)"))
-    DT_ATENDIMENTO = Column(DateTime)
     CD_PACIENTE = Column(String)
+    CD_PRESTADOR = Column(String)
+    DT_ATENDIMENTO = Column(DateTime)
     DT_EXTRACAO = Column(DateTime, server_default=text("now()"))
 
 
@@ -487,6 +488,7 @@ class Reg_Amb(Base):
     id_reg_amb = Column(BigInteger, primary_key=True, server_default=text("nextval('public.id_reg_amb_seq'::regclass)"))
     CD_REG_AMB = Column(String)
     CD_REMESSA = Column(String)
+    DT_REG_AMB = Column(DateTime)
     DT_REMESSA = Column(DateTime)
     DT_EXTRACAO = Column(DateTime, server_default=text("now()"))
 
@@ -500,6 +502,7 @@ class Reg_Fat(Base):
     CD_CONVENIO = Column(String)
     CD_ATENDIMENTO = Column(String)
     CD_REMESSA = Column(String)
+    DT_REG_FAT = Column(DateTime)
     DT_REMESSA = Column(DateTime)
     DT_EXTRACAO = Column(DateTime, server_default=text("now()"))
 


### PR DESCRIPTION
Atualização da  estrutura das tabelas "atendime" , "reg_amb" e "reg_fat".

"atendime" - Precisou receber o campo 'CD_PRESTADOR' pois os registro de "reg_amb" e "reg_fat" sem 'CD_REMESSA' não possuem 'CD_PRESTADOR_REPASSE'.

"reg_amb" / "reg_fat" - 'DT_REG_AMB' e 'DT_REG_FAT' campos marcados para extração incremental