### PR TITLE
refact: Ajuste na referencia da descricao dos procedimentos hospitala…

### DIFF
--- a/dbt_dw_repasse/models/intermediate/int_repasses_medicos.sql
+++ b/dbt_dw_repasse/models/intermediate/int_repasses_medicos.sql
@@ -268,6 +268,8 @@ treats_regra_faturamento
             rf.sn_fechada,
             irf.sn_repassado,
             irf.sn_pertence_pacote,
+            irf.vl_sp,
+            irf.vl_ato,
             irf.vl_unitario,
             irf.vl_total_conta,
             irf.vl_base_repassado
@@ -421,7 +423,19 @@ treats_repasse_regra_faturamento
 
             trf.vl_unitario,
 
-            trf.VL_TOTAL_CONTA AS vl_total_conta,
+            -- trf.vl_base_repassado AS vl_total_conta,
+
+            CASE
+                WHEN trf.vl_base_repassado <> COALESCE(trf.vl_sp, 0) AND COALESCE(trf.vl_ato, 0) = 0 THEN
+                    COALESCE(trf.vl_sp, trf.vl_base_repassado)
+                ELSE
+                    CASE
+                        WHEN trf.vl_base_repassado <> COALESCE(trf.vl_ato, 0) AND COALESCE(trf.vl_sp, 0) = 0 THEN
+                            COALESCE(trf.vl_ato, trf.vl_base_repassado)
+                        ELSE COALESCE(trf.vl_sp, trf.vl_base_repassado)
+                    END
+                -- ELSE COALESCE(trf.vl_ato, 0)
+            END AS vl_total_conta,
 
             trf.vl_base_repassado
 
@@ -437,14 +451,14 @@ treats_repasse_regra_faturamento
             trc.cd_lancamento_fat AS cd_lancamento,
             CONCAT(COALESCE(trc.cd_reg_fat, trc.cd_reg_amb), COALESCE(trc.cd_lancamento_fat, trc.cd_lancamento_amb))::NUMERIC(20,0) AS cd_itreg_key,
 
-            rc.cd_procedimento AS cd_pro_fat,
+            COALESCE(rc.cd_procedimento, rc.cd_pro_fat) AS cd_pro_fat,
 
             rc.cd_gru_pro,
             rc.cd_gru_fat,
             rc.cd_atendimento,
             rc.cd_remessa,
             rc.cd_convenio,
-            rc.cd_ati_med,
+            trc.cd_ati_med,
             trc.cd_prestador_repasse,
             rc.cd_paciente,
             NULL AS dt_itregra,
@@ -462,7 +476,17 @@ treats_repasse_regra_faturamento
 
             NULL AS vl_unitario,
 
-            rc.vl_total_conta,
+            -- rc.vl_total_conta,
+            CASE
+                WHEN rc.vl_base_repassado <> COALESCE(rc.vl_sp, 0) AND rc.vl_sp <> 0 AND COALESCE(rc.vl_ato, 0) = 0 THEN
+                    COALESCE(rc.vl_sp, rc.vl_base_repassado)
+                ELSE
+                    CASE
+                        WHEN rc.vl_base_repassado <> COALESCE(rc.vl_ato, 0) AND COALESCE(rc.vl_sp, 0) = 0 THEN
+                            COALESCE(rc.vl_ato, rc.vl_base_repassado)
+                        ELSE COALESCE(rc.vl_sp, rc.vl_base_repassado)
+                    END
+            END AS vl_total_conta,
 
             rc.vl_base_repassado
 

--- a/dbt_dw_repasse/models/staging/stg_procedimento_sus.sql
+++ b/dbt_dw_repasse/models/staging/stg_procedimento_sus.sql
@@ -15,11 +15,11 @@ WITH source_procedimento_sus
         {% if is_incremental() %}
         WHERE (
                 TRIM(sis.cd_procedimento::TEXT) ~ '^[0-9]+$'
-                AND TRIM(sis.cd_procedimento::TEXT)::NUMERIC(20,0) > (
+                AND LPAD(TRIM(sis.cd_procedimento::TEXT), 21, '0') > (
                     SELECT COALESCE(MAX(CASE
-                        WHEN TRIM(cd_procedimento::TEXT) ~ '^[0-9]+$' THEN TRIM(cd_procedimento::TEXT)::NUMERIC(20,0)
+                        WHEN TRIM(cd_procedimento::TEXT) ~ '^[0-9]+$' THEN LPAD(TRIM(cd_procedimento::TEXT), 21, '0')
                         ELSE NULL
-                    END), 0)
+                    END), LPAD('', 21, '0'))
                     FROM {{ this }}
                 )
             )
@@ -29,7 +29,7 @@ WITH source_procedimento_sus
 treats
     AS (
         SELECT
-            cd_procedimento::BIGINT AS cd_procedimento,
+            TRIM(cd_procedimento::TEXT)::VARCHAR(21) AS cd_procedimento,
             ds_procedimento::VARCHAR(250)
         FROM source_procedimento_sus
 )


### PR DESCRIPTION
refact: Ajuste na referencia da descricao dos procedimentos hospitalares e regra de negocio dos campos ‘vl_total_conta’ e ‘vl_repasse’

O que: 

- Os registros gerados pelo modelo ‘stg_procedimento_sus’ nao estavam em ‘int_procedimento’ p/ os campos de atendimento/conta hospitalar
- No modelo ‘int_repasses_medicos’ a logica da regra de negocio p/ os campos ‘vl_total_conta’ e ‘vl_repasse’ estavam incorreta p/ atendimento/conta hospitalar

para que:

- Registros do SUS obtem ‘ds_procedimento’ pelo campo ‘cd_procedimento’ e registros de convenios obtem ds_procedimento por ‘cd_pro_fat’
- Os campos ‘vl_total_conta’ e ‘vl_repasse’ do modelo ‘int_repasses_medicos’ precisaram ser ajustada para atender necessidades de validacoes da area de negocio

Como:

- Ajuste o tratamento no modelo ‘stg_procedimento_sus’ e em ‘int_repasses_medicos’
- Implemento de condicoes para retornar campos corretamente na CTE ‘treats_repasse_regra_faturamento’